### PR TITLE
fix: log to appropriate statsd meter

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,3 @@
+export { ConsoleReporter } from './console-reporter';
+export { MetricRegistry } from './metric-registry';
+export * from './time';

--- a/src/express/index.ts
+++ b/src/express/index.ts
@@ -1,0 +1,1 @@
+export { instrumented } from './instrumented';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,9 @@
-import { MetricRegistry } from './core/metric-registry';
-
-// reporters
-import { ConsoleReporter } from './core/console-reporter';
-import { StatsdReporter } from './statsd/statsd-reporter';
-export { SimpleStatsdReporter } from './statsd/simple-statsd-reporter';
-export { StatsdConfig } from './statsd/statsd-config';
-
-// node
-import { gauges } from './node/gauges';
-
-// express
-import { instrumented } from './express/instrumented';
+import { MetricRegistry } from './core';
 
 const defaultRegistry = new MetricRegistry();
 
-export {
-  defaultRegistry,
-  ConsoleReporter,
-  gauges,
-  instrumented,
-  MetricRegistry,
-  StatsdReporter
-};
-
-export * from './core/time';
+export * from './core';
+export * from './express';
+export * from './statsd';
+export * from './node';
+export { defaultRegistry };

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,0 +1,1 @@
+export { gauges } from './gauges';

--- a/src/statsd/index.ts
+++ b/src/statsd/index.ts
@@ -1,0 +1,3 @@
+export { SimpleStatsdReporter } from './simple-statsd-reporter';
+export { StatsdConfig } from './statsd-config';
+export { StatsdReporter } from './statsd-reporter';

--- a/src/statsd/simple-statsd-reporter.ts
+++ b/src/statsd/simple-statsd-reporter.ts
@@ -1,21 +1,18 @@
-import { ALL, MetricFilter } from '../core/metric-filter';
-import { MetricRegistry } from '../core/metric-registry';
-import { ScheduledReporter } from '../core/scheduled-reporter';
-
+import { flatten } from 'flat';
+import * as Statsd from 'statsd-client';
+import { MetricRegistry } from '../core';
 import { Counter } from '../core/counter';
 import { Gauge } from '../core/gauge';
 import { Histogram } from '../core/histogram';
 import { Meter } from '../core/meter';
-import { Metered } from '../core/metered';
 import { Metric } from '../core/metric';
+import { ALL, MetricFilter } from '../core/metric-filter';
 import { Metrics } from '../core/metrics';
+import { ScheduledReporter } from '../core/scheduled-reporter';
 import * as timeunit from '../core/time';
 import { Timer } from '../core/timer';
-
 import { StatsdConfig } from './statsd-config';
-
-import { flatten } from 'flat';
-import * as Statsd from 'statsd-client';
+import { sanitizeName } from './statsd-utils';
 
 const STATSD_HOST_OPTION = 'host';
 const STATSD_PORT_OPTION = 'port';
@@ -23,7 +20,7 @@ const REPORTING_METRIC_PREFIX = 'prefix';
 const STATSD_DEFAULT_HOST = 'localhost';
 const STATSD_DEFAULT_PORT = 8125;
 
-class SimpleStatsdReporter extends ScheduledReporter {
+export class SimpleStatsdReporter extends ScheduledReporter {
   private statsd: Statsd;
 
   constructor(
@@ -33,13 +30,7 @@ class SimpleStatsdReporter extends ScheduledReporter {
     durationUnit: timeunit.TimeUnit,
     config: StatsdConfig
   ) {
-    super(
-      registry,
-      'simple-statsd-reporter',
-      ALL,
-      rateUnit,
-      durationUnit
-    );
+    super(registry, 'simple-statsd-reporter', ALL, rateUnit, durationUnit);
     this.statsd = new Statsd({
       host: config[STATSD_HOST_OPTION] || STATSD_DEFAULT_HOST,
       port: config[STATSD_PORT_OPTION] || STATSD_DEFAULT_PORT,
@@ -54,159 +45,25 @@ class SimpleStatsdReporter extends ScheduledReporter {
     meters: Metrics<Meter>,
     timers: Metrics<Timer>
   ): void {
-    const metrics = flatten(
-      {
-        gauges: this.convert(gauges),
-        counters: this.convert(counters),
-        histograms: this.convert(histograms),
-        meters: this.convert(meters),
-        timers: this.convert(timers)
-      }
-    );
-
-    Object.keys(metrics).forEach(name => {
-      this.statsd.gauge(name, metrics[name]);
+    const metrics = flatten({
+      gauges: this.convert(gauges),
+      counters: this.convert(counters),
+      histograms: this.convert(histograms),
+      meters: this.convert(meters),
+      timers: this.convert(timers)
     });
+
+    Object.keys(metrics)
+      .forEach(name => this.statsd.gauge(name, metrics[name]));
   }
 
   private convert(metrics: Metrics<Metric>): any {
     const result = {};
 
-    Object.keys(metrics).forEach(
-      name => (result[name] = metrics[name].toJson())
-    );
+    Object.keys(metrics)
+      .map(sanitizeName)
+      .forEach(name => (result[name] = metrics[name].toJson()));
 
     return result;
   }
-
-  private reportGauge(name: string, gauge: Gauge<any>): void {
-    this.statsd.gauge(name, gauge.getValue());
-  }
-
-  private reportCounter(name: string, counter: Counter): void {
-    this.statsd.increment(name, counter.getCount());
-  }
-
-  private reportMetered(name: string, meter: Metered): void {
-    this.statsd.gauge(
-      MetricRegistry.buildName(name, 'count'),
-      meter.getCount()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'm1_rate'),
-      this.convertRate(meter.getOneMinuteRate())
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'm5_rate'),
-      this.convertRate(meter.getFiveMinuteRate())
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'm15_rate'),
-      this.convertRate(meter.getFifteenMinuteRate())
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'mean_rate'),
-      this.convertRate(meter.getMeanRate())
-    );
-  }
-
-  private reportHistogram(name: string, histogram: Histogram): void {
-    const snapshot = histogram.getSnapshot();
-    this.statsd.gauge(
-      MetricRegistry.buildName(name, 'count'),
-      histogram.getCount()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'max'),
-      snapshot.getMax()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'mean'),
-      snapshot.getMean()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'min'),
-      snapshot.getMin()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'stddev'),
-      snapshot.getStdDev()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p50'),
-      snapshot.getMedian()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p75'),
-      snapshot.get75thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p95'),
-      snapshot.get95thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p98'),
-      snapshot.get98thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p99'),
-      snapshot.get99thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p999'),
-      snapshot.get999thPercentile()
-    );
-  }
-
-  private reportTimer(name: string, timer: Timer): void {
-    const snapshot = timer.getSnapshot();
-    this.statsd.gauge(
-      MetricRegistry.buildName(name, 'count'),
-      timer.getCount()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'max'),
-      snapshot.getMax()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'mean'),
-      snapshot.getMean()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'min'),
-      snapshot.getMin()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'stddev'),
-      snapshot.getStdDev()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p50'),
-      snapshot.getMedian()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p75'),
-      snapshot.get75thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p95'),
-      snapshot.get95thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p98'),
-      snapshot.get98thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p99'),
-      snapshot.get99thPercentile()
-    );
-    this.statsd.timing(
-      MetricRegistry.buildName(name, 'p999'),
-      snapshot.get999thPercentile()
-    );
-
-    this.reportMetered(name, timer);
-  }
 }
-
-export { SimpleStatsdReporter };

--- a/src/statsd/statsd-config.ts
+++ b/src/statsd/statsd-config.ts
@@ -1,7 +1,5 @@
-interface StatsdConfig {
+export interface StatsdConfig {
   host?: string;
   port?: number;
   prefix?: string;
 }
-
-export { StatsdConfig };

--- a/src/statsd/statsd-utils.ts
+++ b/src/statsd/statsd-utils.ts
@@ -1,0 +1,1 @@
+export const sanitizeName = (name: string): string => name.replace(/^\./, '');


### PR DESCRIPTION
We found a bug when working in our services that it was logging to statsd